### PR TITLE
Fixes double wrapped cred offer json

### DIFF
--- a/vcx/libvcx/src/credential.rs
+++ b/vcx/libvcx/src/credential.rs
@@ -245,10 +245,10 @@ impl Credential {
         }
 
         let credential_offer = self.credential_offer.as_ref().ok_or(VcxError::from(VcxErrorKind::InvalidState))?;
-        let credential_offer_json = serde_json::to_string(credential_offer)
+        let credential_offer_json = serde_json::to_value(credential_offer)
             .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidCredential, format!("Cannot deserialize CredentilOffer: {}", err)))?;
 
-        Ok(self.to_cred_offer_string(&credential_offer_json))
+        Ok(self.to_cred_offer_string(credential_offer_json))
     }
 
     fn get_credential_id(&self) -> String {
@@ -270,9 +270,9 @@ impl Credential {
         serde_json::Value::from(json).to_string()
     }
 
-    fn to_cred_offer_string(&self, cred_offer: &str) -> String {
+    fn to_cred_offer_string(&self, cred_offer: Value) -> String {
         let mut json = serde_json::Map::new();
-        json.insert("credential_offer".to_string(), Value::String(cred_offer.to_string()));
+        json.insert("credential_offer".to_string(), cred_offer);
         self.set_payment_info(&mut json);
         serde_json::Value::from(json).to_string()
     }
@@ -725,5 +725,16 @@ pub mod tests {
         assert!(cred.send_request(1234).is_err());
         let new_balance = get_wallet_token_info().unwrap().get_balance();
         assert_eq!(new_balance, balance);
+    }
+
+    #[test]
+    fn test_get_cred_offer_returns_json_string_with_cred_offer_json_nested() {
+        init!("true");
+        let handle = from_string(::utils::constants::DEFAULT_SERIALIZED_CREDENTIAL).unwrap();
+        let offer_string = get_credential_offer(handle).unwrap();
+        let offer_value: serde_json::Value = serde_json::from_str(&offer_string).unwrap();
+
+        let offer_struct: CredentialOffer = serde_json::from_value(offer_value["credential_offer"].clone()).unwrap();
+
     }
 }


### PR DESCRIPTION
A valid format for get_cred_offer is a string json which includes fields that are json structured, not string.

Good Example: 
"{\"credential_offer\":{\"claim_id\":\"defaultCredentialId\",.....}...}"

Bad Example:
"{\"credential_offer\":\"{\\\"claim_id\\\":\\\"defaultCredentialId\\\", ..}", ....}
Signed-off-by: Ryan Marsh <ryan.marsh44@gmail.com>