### PR TITLE
enable alternative vcx_init with preconfigured wallet/pool

### DIFF
--- a/vcx/ci/Jenkinsfile
+++ b/vcx/ci/Jenkinsfile
@@ -235,13 +235,11 @@ def mainUbuntu() {
                             // ******** Publish Python Package to filely repo *********
                             sh "vcx/ci/scripts/publish.sh \"${KRAKEN_CREDENTIALS}\" \"python3-vcx-wrapper*.tar.gz\" https://kraken.corp.evernym.com/repo/python/upload"
                         }
-//                        withCredentials([file(credentialsId: 'artifactory-evernym-settings', variable: 'settingsFile')]) {
-//                            java.inside() {
-//                                sh 'cp $settingsFile .'
-//                                sh "chmod +x vcx/wrappers/java/ci/publishJar.sh"
-//                                sh 'vcx/wrappers/java/ci/publishJar.sh'
-//                            }
-//                        }
+                    }
+                   withCredentials([file(credentialsId: 'cloudrepo-artifactory-settings-libvcx', variable: 'settingsFile')]) {
+                        sh 'cp $settingsFile .'
+                        sh "chmod +x vcx/wrappers/java/ci/publishJar.sh"
+                        sh 'vcx/wrappers/java/ci/publishJar.sh'
                     }
                 }
             }

--- a/vcx/dummy-cloud-agent/src/domain/a2a.rs
+++ b/vcx/dummy-cloud-agent/src/domain/a2a.rs
@@ -394,17 +394,6 @@ impl From<ConnectionRequest> for ConnectionRequestMessageDetail {
     }
 }
 
-impl From<ConnectionRequest> for ConnectionRequestMessageDetail {
-    fn from(con_req: ConnectionRequest) -> Self {
-        ConnectionRequestMessageDetail {
-            key_dlg_proof: con_req.key_dlg_proof,
-            target_name: con_req.target_name,
-            phone_no: con_req.phone_no,
-            use_public_did: Some(con_req.include_public_did),
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConnectionRequestMessageDetailResp {
     #[serde(rename = "inviteDetail")]
@@ -435,17 +424,6 @@ impl From<ConnectionRequestAnswer> for ConnectionRequestAnswerMessageDetail {
             sender_agency_detail: con_req_answer.sender_agency_detail,
             answer_status_code: con_req_answer.answer_status_code,
             thread: Some(con_req_answer.thread),
-        }
-    }
-}
-
-impl From<ConnectionRequestAnswer> for ConnectionRequestAnswerMessageDetail {
-    fn from(con_req_answer: ConnectionRequestAnswer) -> Self {
-        ConnectionRequestAnswerMessageDetail {
-            key_dlg_proof: con_req_answer.key_dlg_proof,
-            sender_detail: con_req_answer.sender_detail,
-            sender_agency_detail: con_req_answer.sender_agency_detail,
-            answer_status_code: con_req_answer.answer_status_code,
         }
     }
 }

--- a/vcx/libvcx/src/api/extensions.rs
+++ b/vcx/libvcx/src/api/extensions.rs
@@ -1,0 +1,160 @@
+use utils::version_constants;
+use libc::c_char;
+use utils::cstring::CStringUtils;
+use utils::libindy::{wallet, pool};
+use utils::error;
+use settings;
+use error::prelude::*;
+
+#[no_mangle]
+pub extern fn vcx_wallet_get_handle() -> i32 {
+    wallet::get_wallet_handle()
+}
+
+#[no_mangle]
+pub extern fn vcx_pool_get_handle() -> i32 {
+    match pool::get_pool_handle() {
+        Ok(x) => x,
+        Err(_) => 0,
+    }
+}
+
+#[no_mangle]
+pub extern fn vcx_wallet_set_handle(handle: i32) -> i32 {
+    wallet::set_wallet_handle(handle)
+}
+
+#[no_mangle]
+pub extern fn vcx_pool_set_handle(handle: i32) -> i32 {
+    if handle <= 0 { pool::change_pool_handle(None); }
+    else { pool::change_pool_handle(Some(handle)); }
+
+    handle
+}
+
+#[no_mangle]
+pub extern fn vcx_init_post_indy(config: *const c_char) -> u32 {
+    check_useful_c_str!(config,VcxErrorKind::InvalidOption);
+
+    trace!("vcx_init_without_indy(config: {:?})", config);
+
+    if config == "ENABLE_TEST_MODE" {
+        settings::set_config_value(settings::CONFIG_ENABLE_TEST_MODE, "true");
+        settings::set_defaults();
+    } else {
+        match settings::process_config_string(&config) {
+            Err(e) => {
+                error!("Invalid configuration specified: {}", e);
+                return e.into();
+            }
+            Ok(_) => (),
+        }
+    };
+
+    if wallet::get_wallet_handle() <= 0 || pool::get_pool_handle().is_err() {
+        error!("Library was initialized without wallet/pool");
+        return error::INVALID_STATE.code_num;
+    }
+
+    ::utils::threadpool::init();
+
+    settings::log_settings();
+
+    trace!("libvcx version: {}{}", version_constants::VERSION, version_constants::REVISION);
+
+    error::SUCCESS.code_num
+}
+
+extern {
+    fn indy_pack_message(command_handle: i32,
+                         wallet_handle: i32,
+                         message: *const u8,
+                         message_len: u32,
+                         receiver_keys: *const c_char,
+                         sender: *const c_char,
+                         cb: Option<extern fn(xcommand_handle: i32, err: i32, jwe_data: *const u8, jwe_len: u32)>) -> i32;
+
+    fn indy_unpack_message(command_handle: i32,
+                           wallet_handle: i32,
+                           jwe_data: *const u8,
+                           jwe_len: u32,
+                           cb: Option<extern fn(xcommand_handle: i32, err: i32, res_json_data: *const u8, res_json_len: u32 )>) -> i32;
+}
+
+#[no_mangle]
+pub extern fn vcx_pack_message(command_handle: i32,
+                               wallet_handle: i32, //ignored
+                               message: *const u8,
+                               message_len: u32,
+                               receiver_keys: *const c_char,
+                               sender: *const c_char,
+                               cb: Option<extern fn(xcommand_handle: i32, err: i32, jwe_data: *const u8, jwe_len: u32)>) -> i32 {
+    unsafe {
+        indy_pack_message(command_handle, wallet::get_wallet_handle(), message, message_len, receiver_keys, sender, cb)
+    }
+}
+
+#[no_mangle]
+pub extern fn vcx_unpack_message(command_handle: i32,
+                                 wallet_handle: i32, //ignored
+                                 jwe_data: *const u8,
+                                 jwe_len: u32,
+                                 cb: Option<extern fn(xcommand_handle: i32, err: i32, res_json_data : *const u8, res_json_len : u32)>) -> i32 {
+    unsafe {
+        indy_unpack_message(command_handle, wallet::get_wallet_handle(), jwe_data, jwe_len, cb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_settings() -> String {
+        json!({
+            settings::CONFIG_AGENCY_DID:           settings::get_config_value(settings::CONFIG_AGENCY_DID).unwrap(),
+            settings::CONFIG_AGENCY_VERKEY:        settings::get_config_value(settings::CONFIG_AGENCY_VERKEY).unwrap(),
+            settings::CONFIG_AGENCY_ENDPOINT:      settings::get_config_value(settings::CONFIG_AGENCY_ENDPOINT).unwrap(),
+            settings::CONFIG_REMOTE_TO_SDK_DID:    settings::get_config_value(settings::CONFIG_REMOTE_TO_SDK_DID).unwrap(),
+            settings::CONFIG_REMOTE_TO_SDK_VERKEY: settings::get_config_value(settings::CONFIG_REMOTE_TO_SDK_VERKEY).unwrap(),
+            settings::CONFIG_SDK_TO_REMOTE_DID:    settings::get_config_value(settings::CONFIG_SDK_TO_REMOTE_DID).unwrap(),
+            settings::CONFIG_SDK_TO_REMOTE_VERKEY: settings::get_config_value(settings::CONFIG_SDK_TO_REMOTE_VERKEY).unwrap(),
+            settings::CONFIG_INSTITUTION_NAME:     settings::get_config_value(settings::CONFIG_INSTITUTION_NAME).unwrap(),
+            settings::CONFIG_INSTITUTION_DID:      settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap(),
+            settings::CONFIG_INSTITUTION_LOGO_URL: settings::get_config_value(settings::CONFIG_INSTITUTION_LOGO_URL).unwrap(),
+            settings::CONFIG_PAYMENT_METHOD:       settings::get_config_value(settings::CONFIG_PAYMENT_METHOD).unwrap()
+        }).to_string()
+    }
+
+    #[cfg(feature = "pool_tests")]
+    #[cfg(feature = "agency")]
+    #[test]
+    fn test_init_post_indy() {
+	use std::ffi::CString;
+
+        init!("agency");
+        let content = get_settings();
+        settings::clear_config();
+        // Store settings and handles
+        let config = CString::new(content).unwrap().into_raw();
+        let wallet_handle = vcx_wallet_get_handle();
+        let pool_handle = vcx_pool_get_handle();
+        assert!(wallet_handle > 0);
+        assert!(pool_handle > 0);
+        // Reset handles to 0
+        assert_eq!(vcx_pool_set_handle(0), 0);
+        assert_eq!(vcx_wallet_set_handle(0), 0);
+        assert_eq!(vcx_wallet_get_handle(), 0);
+        assert_eq!(vcx_pool_get_handle(), 0);
+        // Test for errors when handles not set
+        assert_ne!(error::SUCCESS.code_num, vcx_init_post_indy(config));
+        vcx_wallet_set_handle(wallet_handle);
+        assert_ne!(error::SUCCESS.code_num, vcx_init_post_indy(config));
+        vcx_pool_set_handle(pool_handle);
+        // NOTE: handles are set independently, test config with no wallet or pool
+        assert_eq!(error::SUCCESS.code_num, vcx_init_post_indy(config));
+        // test that wallet and pool are operational
+        ::utils::libindy::anoncreds::tests::create_and_store_credential(::utils::constants::DEFAULT_SCHEMA_ATTRS, false);
+        assert!(::connection::tests::build_test_connection() > 0);
+        teardown!("agency");
+    }
+}

--- a/vcx/libvcx/src/api/mod.rs
+++ b/vcx/libvcx/src/api/mod.rs
@@ -10,6 +10,7 @@ pub mod disclosed_proof;
 pub mod wallet;
 pub mod logger;
 pub mod return_types_u32;
+pub mod extensions;
 
 use std::fmt;
 

--- a/vcx/libvcx/src/messages/get_message.rs
+++ b/vcx/libvcx/src/messages/get_message.rs
@@ -451,7 +451,6 @@ mod tests {
     fn test_download_messages() {
         use std::thread;
         use std::time::Duration;
-        ::utils::logger::LibvcxDefaultLogger::init_testing_logger();
 
         init!("agency");
         let institution_did = settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap();

--- a/vcx/libvcx/src/settings.rs
+++ b/vcx/libvcx/src/settings.rs
@@ -119,7 +119,7 @@ pub fn validate_config(config: &HashMap<String, String>) -> VcxResult<u32> {
     trace!("validate_config >>> config: {:?}", config);
 
     //Mandatory parameters
-    if config.get(CONFIG_WALLET_KEY).is_none() {
+    if ::utils::libindy::wallet::get_wallet_handle() == 0 && config.get(CONFIG_WALLET_KEY).is_none() {
         return Err(VcxError::from(VcxErrorKind::MissingWalletKey));
     }
 
@@ -487,6 +487,7 @@ pub mod tests {
         let valid_did = DEFAULT_DID;
         let valid_ver = DEFAULT_VERKEY;
 
+        ::utils::libindy::wallet::set_wallet_handle(0);
         let mut config: HashMap<String, String> = HashMap::new();
         assert_eq!(validate_config(&config).unwrap_err().kind(), VcxErrorKind::MissingWalletKey);
 

--- a/vcx/wrappers/java/ci/publishJar.sh
+++ b/vcx/wrappers/java/ci/publishJar.sh
@@ -8,8 +8,8 @@ cp -v settings.xml ${JAR_FOLDER}
 pushd ${JAR_FOLDER}
 
     mvn -e deploy:deploy-file \
-        -Durl="https://repo.evernym.com/artifactory/libindy-maven-local" \
-        -DrepositoryId="artifactory-evernym" \
+        -Durl="https://evernym.mycloudrepo.io/repositories/libvcx-java" \
+        -DrepositoryId="io.cloudrepo" \
         -Dversion=${JAR_VERSION} \
         -Dname="vcx" \
         -Dfile="com.evernym-vcx-${JAR_VERSION}.jar" \

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -486,8 +486,23 @@ public abstract class LibVcx {
         int vcx_set_logger(Pointer context, Callback enabled, Callback log, Callback flush);
         int vcx_set_default_logger(String log_level);
 
-		int indy_crypto_anon_crypt(int command_handle, String their_vk, byte[] message_raw, int message_len, Callback cb);
-		int indy_crypto_anon_decrypt(int command_handle, int wallet_handle, String my_vk, byte[] encrypted_msg_raw, int encrypted_msg_len, Callback cb);
+        /**
+         * Evernym extensions
+         */
+
+        int indy_crypto_anon_crypt(int command_handle, String their_vk, byte[] message_raw, int message_len, Callback cb);
+        int indy_crypto_anon_decrypt(int command_handle, int wallet_handle, String my_vk, byte[] encrypted_msg_raw, int encrypted_msg_len, Callback cb);
+
+        /** Get wallet handle in use by libvcx */
+        int vcx_wallet_get_handle();
+        /** Get pool handle in use by libvcx */
+        int vcx_pool_get_handle();
+        /** Set pool handle */
+        int vcx_pool_set_handle(int handle);
+        /** Set wallet handle */
+        int vcx_wallet_set_handle(int handle);
+        /** Verity specific vcx_init, requires that wallet and pool handles are already set via vcx_wallet/pool_set_handle */
+        int vcx_init_post_indy(String config);
     }
 
     /*

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/vcx/VcxApi.java
@@ -232,4 +232,34 @@ public class VcxApi extends VcxJava.API {
         return future;
     }
 
+    /** Evernym extensions */
+    public static int vcxGetWalletHandle() {
+        logger.debug("vcxGetWalletHandle() called");
+        int handle = LibVcx.api.vcx_wallet_get_handle();
+        return handle;
+    }
+
+    public static int vcxGetPoolHandle() {
+        logger.debug("vcxGetPoolHandle() called");
+        int handle = LibVcx.api.vcx_pool_get_handle();
+        return handle;
+    }
+
+    public static int vcxSetPoolHandle(int handle) {
+        logger.debug("vcxSetPoolHandle() called");
+        handle = LibVcx.api.vcx_pool_set_handle(handle);
+        return handle;
+    }
+
+    public static int vcxSetWalletHandle(int handle) {
+        logger.debug("vcxSetWalletHandle() called");
+        handle = LibVcx.api.vcx_wallet_set_handle(handle);
+        return handle;
+    }
+
+    public static int vcxInitPostIndy(String config) {
+        logger.debug("vcxInitPostIndy() called");
+        int error = LibVcx.api.vcx_init_post_indy(config);
+        return error;
+    }
 }

--- a/vcx/wrappers/java/src/test/java/com/evernym/sdk/vcx/VcxApiTest.java
+++ b/vcx/wrappers/java/src/test/java/com/evernym/sdk/vcx/VcxApiTest.java
@@ -46,4 +46,41 @@ public class VcxApiTest {
         String errorCMessage = VcxApi.vcxErrorCMessage(1001);
         assert (errorCMessage.equals("Unknown Error"));
     }
+
+    /** Evernym extensions */
+    @Test
+    @DisplayName("get wallet handle")
+    void vcxGetWalletHandle() {
+        int Handle = VcxApi.vcxGetWalletHandle();
+        assert (Handle == 1);
+    }
+
+    @Test
+    @DisplayName("get pool handle")
+    void vcxGetPoolHandle() {
+        int Handle = VcxApi.vcxGetPoolHandle();
+        assert (Handle == 0);
+    }
+
+    @Test
+    @DisplayName("set pool handle")
+    void vcxSetPoolHandle() {
+        int Handle = VcxApi.vcxSetPoolHandle(1);
+        assert (Handle == 1);
+    }
+
+    @Test
+    @DisplayName("set pool handle")
+    void vcxSetWalletHandle() {
+        int Handle = VcxApi.vcxSetWalletHandle(1);
+        assert (Handle == 1);
+    }
+
+    @Test
+    @DisplayName("init with pool/wallet already set")
+    void vcxInitPostIndy() {
+        int error = VcxApi.vcxInitPostIndy("ENABLE_TEST_MODE");;
+        assert (error == 0);
+    }
+
 }

--- a/vcx/wrappers/node/src/api/extensions.ts
+++ b/vcx/wrappers/node/src/api/extensions.ts
@@ -1,0 +1,114 @@
+import * as ffi from 'ffi'
+import * as ref from 'ref'
+import { VCXInternalError } from '../errors'
+import { rustAPI } from '../rustlib'
+import { createFFICallbackPromise } from '../utils/ffi-helpers'
+
+function voidPtrToUint8Array (origPtr: any, length: number): Buffer {
+    /**
+     * Read the contents of the pointer and copy it into a new Buffer
+     */
+  const ptrType = ref.refType('uint8 *')
+  const pointerBuf = ref.alloc(ptrType, origPtr)
+  const newPtr = ref.readPointer(pointerBuf, 0, length)
+  const newBuffer = Buffer.from(newPtr)
+  return newBuffer
+}
+
+export interface IPackMessageData {
+  data: Buffer,
+  keys: string,
+  sender: string
+}
+
+export interface IUnpackMessageData {
+  data: Buffer,
+}
+
+export class Connection {
+  public getWalletHandle (): number {
+    return rustAPI().vcx_wallet_get_handle()
+  }
+
+  public getPoolHandle (): number {
+    return rustAPI().vcx_pool_get_handle()
+  }
+
+  /**
+   * Pack message.
+   *
+   * Example:
+   * ```
+   * ```
+   * @returns {Promise<string}
+   */
+  public async packMessage ({ data, keys, sender }: IPackMessageData): Promise<Buffer> {
+    try {
+      return await createFFICallbackPromise<Buffer>(
+          (resolve, reject, cb) => {
+            const rc = rustAPI().vcx_pack_message(0, 0,
+              ref.address(data), data.length, keys, sender, cb)
+            if (rc) {
+              reject(rc)
+            }
+          },
+          (resolve, reject) => ffi.Callback(
+            'void',
+            ['uint32', 'uint32', 'pointer', 'uint32'],
+            (xHandle: number, err: number, details: any, length: number) => {
+              if (err) {
+                reject(err)
+                return
+              }
+              if (!details) {
+                reject(`returned empty buffer`)
+                return
+              }
+              const newBuffer = voidPtrToUint8Array(details, length)
+              resolve(newBuffer)
+            })
+        )
+    } catch (err) {
+      throw new VCXInternalError(err)
+    }
+  }
+
+ /**
+  * Unpack message.
+  *
+  * Example:
+  * ```
+  * ```
+  * @returns {Promise<string}
+  */
+  public async unpackMessage (unpackData: IUnpackMessageData): Promise<Buffer> {
+    try {
+      return await createFFICallbackPromise<Buffer>(
+          (resolve, reject, cb) => {
+            const rc = rustAPI().vcx_unpack_message(0, 0,
+              ref.address(unpackData.data), unpackData.data.length, cb)
+            if (rc) {
+              reject(rc)
+            }
+          },
+          (resolve, reject) => ffi.Callback(
+            'void',
+            ['uint32', 'uint32', 'pointer', 'uint32'],
+            (xHandle: number, err: number, details: any, length: number) => {
+              if (err) {
+                reject(err)
+                return
+              }
+              if (!details) {
+                reject(`returned empty buffer`)
+                return
+              }
+              const newBuffer = voidPtrToUint8Array(details, length)
+              resolve(newBuffer)
+            })
+        )
+    } catch (err) {
+      throw new VCXInternalError(err)
+    }
+  }
+}

--- a/vcx/wrappers/node/src/rustlib.ts
+++ b/vcx/wrappers/node/src/rustlib.ts
@@ -35,6 +35,9 @@ export const FFI_LOG_FN = 'pointer'
 export const FFI_POINTER = 'pointer'
 export const FFI_VOID_POINTER = 'void *'
 
+// Evernym extensions
+export const FFI_INDY_NUMBER = 'int32'
+
 // Rust Lib Native Types
 export type rust_did = string
 export type rust_error_code = number
@@ -54,6 +57,13 @@ export interface IFFIEntryPoint {
   vcx_version: () => string,
   vcx_messages_download: (commandId: number, status: string, uids: string, pairwiseDids: string, cb: any) => number,
   vcx_messages_update_status: (commandId: number, status: string, msgIds: string, cb: any) => number,
+
+  // Evernym extensions
+  vcx_wallet_get_handle: () => number,
+  vcx_pool_get_handle: () => number,
+  vcx_pack_message: (commandId: number, walletHandle: number, message: number, messageLen: number, keys: string,
+                     sender: string, cb: any) => number,
+  vcx_unpack_message: (commandId: number, walletHandle: number, jweData: number, jweLen: number, cb: any) => number,
 
   // wallet
   vcx_wallet_get_token_info: (commandId: number, payment: number | undefined | null, cb: any) => number,
@@ -192,6 +202,14 @@ export const FFIConfiguration: { [ Key in keyof IFFIEntryPoint ]: any } = {
   vcx_messages_download: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA,
     FFI_STRING_DATA, FFI_CALLBACK_PTR]],
   vcx_messages_update_status: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA,
+    FFI_CALLBACK_PTR]],
+
+  // Evernym extensions
+  vcx_wallet_get_handle: [FFI_INDY_NUMBER, []],
+  vcx_pool_get_handle: [FFI_INDY_NUMBER, []],
+  vcx_pack_message: [FFI_INDY_NUMBER, [FFI_INDY_NUMBER, FFI_INDY_NUMBER, FFI_UNSIGNED_INT, FFI_UNSIGNED_INT,
+    FFI_STRING, FFI_STRING, FFI_CALLBACK_PTR]],
+  vcx_unpack_message: [FFI_INDY_NUMBER, [FFI_INDY_NUMBER, FFI_INDY_NUMBER, FFI_UNSIGNED_INT, FFI_UNSIGNED_INT,
     FFI_CALLBACK_PTR]],
 
   // wallet


### PR DESCRIPTION
The wallet and pool must be set using the new "set" routines before
using the new vcx_init functions. These are Evernym specific and
won't be part of the hyperledger repo.

Signed-off-by: Douglas Wightman <douglas.wightman@evernym.com>