### PR TITLE
CM-2245 Hide PII information from logs.

### DIFF
--- a/vcx/libvcx/src/api/credential.rs
+++ b/vcx/libvcx/src/api/credential.rs
@@ -85,7 +85,7 @@ pub extern fn vcx_credential_create_with_offer(command_handle: u32,
     check_useful_c_str!(offer, VcxErrorKind::InvalidOption);
 
     trace!("vcx_credential_create_with_offer(command_handle: {}, source_id: {}, offer: {})",
-           command_handle, source_id, offer);
+           command_handle, source_id, secret!(&offer));
 
     spawn(move || {
         match credential::credential_create_with_offer(&source_id, &offer) {

--- a/vcx/libvcx/src/api/issuer_credential.rs
+++ b/vcx/libvcx/src/api/issuer_credential.rs
@@ -76,7 +76,7 @@ pub extern fn vcx_issuer_create_credential(command_handle: u32,
            source_id,
            cred_def_handle,
            issuer_did,
-           credential_data,
+           secret!(&credential_data),
            credential_name);
 
     spawn(move || {

--- a/vcx/libvcx/src/api/wallet.rs
+++ b/vcx/libvcx/src/api/wallet.rs
@@ -151,7 +151,7 @@ pub extern fn vcx_wallet_add_record(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_add_record(command_handle: {}, type_: {}, id: {}, value: {}, tags_json: {})",
-          command_handle, type_, id, value, tags_json);
+          command_handle, secret!(&type_), secret!(&id), secret!(&value), secret!(&tags_json));
 
     spawn(move|| {
         match wallet::add_record(&type_, &id, &value, Some(&tags_json)) {
@@ -207,7 +207,7 @@ pub extern fn vcx_wallet_update_record_value(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_update_record_value(command_handle: {}, type_: {}, id: {}, value: {})",
-          command_handle, type_, id, value);
+          command_handle, secret!(&type_), secret!(&id), secret!(&value));
 
     spawn(move|| {
         match wallet::update_record_value(&type_, &id, &value) {
@@ -263,7 +263,7 @@ pub extern fn vcx_wallet_update_record_tags(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_update_record_tags(command_handle: {}, type_: {}, id: {}, tags: {})",
-           command_handle, type_, id, tags);
+           command_handle, secret!(&type_), secret!(&id), secret!(&tags));
 
     spawn(move|| {
         cb(command_handle, error::SUCCESS.code_num);
@@ -306,7 +306,7 @@ pub extern fn vcx_wallet_add_record_tags(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_add_record_tags(command_handle: {}, type_: {}, id: {}, tags: {})",
-           command_handle, type_, id, tags);
+           command_handle, secret!(&type_), secret!(&id), secret!(&tags));
 
     spawn(move|| {
         cb(command_handle, error::SUCCESS.code_num);
@@ -348,7 +348,7 @@ pub extern fn vcx_wallet_delete_record_tags(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_delete_record_tags(command_handle: {}, type_: {}, id: {}, tags: {})",
-           command_handle, type_, id, tags);
+           command_handle, secret!(&type_), secret!(&id), secret!(&tags));
 
     spawn(move|| {
         cb(command_handle, error::SUCCESS.code_num);
@@ -389,7 +389,7 @@ pub extern fn vcx_wallet_get_record(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_get_record(command_handle: {}, type_: {}, id: {}, options: {})",
-          command_handle, type_, id, options_json);
+          command_handle, secret!(&type_), secret!(&id), options_json);
 
     spawn(move|| {
         match wallet::get_record(&type_, &id, &options_json) {
@@ -445,7 +445,7 @@ pub extern fn vcx_wallet_delete_record(command_handle: u32,
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     trace!("vcx_wallet_delete_record(command_handle: {}, type_: {}, id: {})",
-          command_handle, type_, id);
+          command_handle, secret!(&type_), secret!(&id));
 
     spawn(move|| {
         match wallet::delete_record(&type_, &id) {

--- a/vcx/libvcx/src/credential.rs
+++ b/vcx/libvcx/src/credential.rs
@@ -84,7 +84,7 @@ impl Credential {
         let (cred_def_id, cred_def_json) = anoncreds::get_cred_def_json(&credential_offer.cred_def_id)?;
 
         /*
-                debug!("storing credential offer: {}", credential_offer);
+                debug!("storing credential offer: {}", secret!(&credential_offer));
                 libindy_prover_store_credential_offer(wallet_h, &credential_offer).map_err(|ec| CredentialError::CommonError(ec))?;
         */
 
@@ -337,7 +337,7 @@ fn handle_err(err: VcxError) -> VcxError {
 }
 
 pub fn credential_create_with_offer(source_id: &str, offer: &str) -> VcxResult<u32> {
-    trace!("credential_create_with_offer >>> source_id: {}, offer: {}", source_id, offer);
+    trace!("credential_create_with_offer >>> source_id: {}, offer: {}", source_id, secret!(&offer));
 
     let mut new_credential = _credential_create(source_id);
 

--- a/vcx/libvcx/src/disclosed_proof.rs
+++ b/vcx/libvcx/src/disclosed_proof.rs
@@ -339,7 +339,7 @@ impl DisclosedProof {
     }
 
     fn generate_proof(&mut self, credentials: &str, self_attested_attrs: &str) -> VcxResult<u32> {
-        trace!("DisclosedProof::generate_proof >>> credentials: {}, self_attested_attrs: {}", credentials, self_attested_attrs);
+        trace!("DisclosedProof::generate_proof >>> credentials: {}, self_attested_attrs: {}", secret!(&credentials), secret!(&self_attested_attrs));
 
         debug!("generating proof {}", self.source_id);
         if settings::test_indy_mode_enabled() { return Ok(error::SUCCESS.code_num); }
@@ -441,7 +441,7 @@ impl DisclosedProof {
             .map_err(|err| err.extend("Cannot serialize DisclosedProof"))
     }
     fn from_str(data: &str) -> VcxResult<DisclosedProof> {
-        trace!("DisclosedProof::from_str >>> data: {}", data);
+        trace!("DisclosedProof::from_str >>> data: {}", secret!(&data));
         ObjectWithVersion::deserialize(data)
             .map(|obj: ObjectWithVersion<DisclosedProof>| obj.data)
             .map_err(|err| err.extend("Cannot deserialize DisclosedProof"))

--- a/vcx/libvcx/src/issuer_credential.rs
+++ b/vcx/libvcx/src/issuer_credential.rs
@@ -165,7 +165,7 @@ impl IssuerCredential {
         let payload = serde_json::to_string(&payload)
             .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize payload: {}", err)))?;
 
-        debug!("credential offer data: {}", payload);
+        debug!("credential offer data: {}", secret!(&payload));
 
         let response =
             messages::send_message()
@@ -215,7 +215,7 @@ impl IssuerCredential {
                 .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidCredential, format!("Cannot serialize credential: {}", err)))?
         };
 
-        debug!("credential data: {}", data);
+        debug!("credential data: {}", secret!(&data));
 
         let cred_req_msg_id = self.credential_request
             .as_ref()
@@ -520,7 +520,7 @@ pub fn issuer_credential_create(cred_def_handle: u32,
                                 credential_data: String,
                                 price: u64) -> VcxResult<u32> {
     trace!("issuer_credential_create >>> cred_def_handle: {}, source_id: {}, issuer_did: {}, credential_name: {}, credential_data: {}, price: {}",
-           cred_def_handle, source_id, issuer_did, credential_name, credential_data, price);
+           cred_def_handle, source_id, issuer_did, credential_name, secret!(&credential_data), price);
 
     let cred_def_id = ::credential_def::get_cred_def_id(cred_def_handle)?;
     let rev_reg_id = ::credential_def::get_rev_reg_id(cred_def_handle)?;

--- a/vcx/libvcx/src/utils/libindy/wallet.rs
+++ b/vcx/libvcx/src/utils/libindy/wallet.rs
@@ -96,7 +96,7 @@ pub fn delete_wallet(wallet_name: &str, wallet_type: Option<&str>, storage_confi
 }
 
 pub fn add_record(xtype: &str, id: &str, value: &str, tags: Option<&str>) -> VcxResult<()> {
-    trace!("add_record >>> xtype: {}, id: {}, value: {}, tags: {:?}", xtype, id, value, tags);
+    trace!("add_record >>> xtype: {}, id: {}, value: {}, tags: {:?}", secret!(&xtype), secret!(&id), secret!(&value), secret!(&tags));
 
     if settings::test_indy_mode_enabled() { return Ok(()); }
 
@@ -107,7 +107,7 @@ pub fn add_record(xtype: &str, id: &str, value: &str, tags: Option<&str>) -> Vcx
 
 
 pub fn get_record(xtype: &str, id: &str, options: &str) -> VcxResult<String> {
-    trace!("get_record >>> xtype: {}, id: {}, options: {}", xtype, id, options);
+    trace!("get_record >>> xtype: {}, id: {}, options: {}", secret!(&xtype), secret!(&id), options);
 
     if settings::test_indy_mode_enabled() {
         return Ok(r#"{"id":"123","type":"record type","value":"record value","tags":null}"#.to_string());
@@ -119,7 +119,7 @@ pub fn get_record(xtype: &str, id: &str, options: &str) -> VcxResult<String> {
 }
 
 pub fn delete_record(xtype: &str, id: &str) -> VcxResult<()> {
-    trace!("delete_record >>> xtype: {}, id: {}", xtype, id);
+    trace!("delete_record >>> xtype: {}, id: {}", secret!(&xtype), secret!(&id));
 
     if settings::test_indy_mode_enabled() { return Ok(()); }
 
@@ -130,7 +130,7 @@ pub fn delete_record(xtype: &str, id: &str) -> VcxResult<()> {
 
 
 pub fn update_record_value(xtype: &str, id: &str, value: &str) -> VcxResult<()> {
-    trace!("update_record_value >>> xtype: {}, id: {}, value: {}", xtype, id, value);
+    trace!("update_record_value >>> xtype: {}, id: {}, value: {}", secret!(&xtype), secret!(&id), secret!(&value));
 
     if settings::test_indy_mode_enabled() { return Ok(()); }
 

--- a/vcx/libvcx/src/utils/mod.rs
+++ b/vcx/libvcx/src/utils/mod.rs
@@ -10,6 +10,18 @@ pub mod version_constants;
 #[macro_use]
 pub mod devsetup;
 
+#[cfg(debug_assertions)]
+#[macro_export]
+macro_rules! secret {
+    ($val:expr) => {{ $val }};
+}
+
+#[cfg(not(debug_assertions))]
+#[macro_export]
+macro_rules! secret {
+    ($val:expr) => {{ "_" }};
+}
+
 pub mod error;
 pub mod httpclient;
 pub mod constants;


### PR DESCRIPTION
Introduce macro "secret!" which hides PII information in release version.
If compiled in a debug mode, PII is still being logged.

Signed-off-by: Darko Kulic darko.kulic@evernym.com